### PR TITLE
Support specifying digest length

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ console.log(h.digest());
 console.log(j.digest());
 ```
 
+### Digest Length
+
+BLAKE2 can generate digests between 1 and 64 (BLAKE2b) or 32 (BLAKE2s) bytes.
+Pass `digestLength` as an option to use a non-default digest length:
+
+```js
+var blake2 = require('blake2');
+var h = blake2.createHash('blake2b', { digestLength: 16 });
+h.update(new Buffer("test"));
+h.digest(); // Returns a buffer of 16 bytes
+```
 
 Known issues
 ---

--- a/index.js
+++ b/index.js
@@ -44,7 +44,12 @@ class LazyTransform extends stream.Transform {
 class Hash extends LazyTransform {
 	constructor(algorithm, options) {
 		super(options);
-		this._handle = new binding.Hash(algorithm);
+
+		var digestLength = -1;
+		if (options && 'digestLength' in options) {
+			digestLength = options.digestLength;
+		}
+		this._handle = new binding.Hash(algorithm, null, digestLength);
 	}
 
 	_transform(chunk, encoding, callback) {
@@ -85,7 +90,9 @@ function createHash(algorithm, options) {
 class KeyedHash extends LazyTransform {
 	constructor(algorithm, key, options) {
 		super(options);
-		this._handle = new binding.Hash(algorithm, key);
+
+		var digestLength = (options && options['digestLength']) || -1;
+		this._handle = new binding.Hash(algorithm, key, digestLength);
 	}
 }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -56,34 +56,54 @@ public:
 
 		const char *key_data = nullptr;
 		size_t key_length;
+		int digest_length;
 		if(algo != "bypass" && info.Length() >= 2) {
-			if(!node::Buffer::HasInstance(info[1])) {
-				return Nan::ThrowError(v8::Exception::TypeError(Nan::New<v8::String>("If key argument is given, it must be a Buffer").ToLocalChecked()));
+			if (!info[1]->IsNull()) {
+				if(!node::Buffer::HasInstance(info[1])) {
+					return Nan::ThrowError(v8::Exception::TypeError(Nan::New<v8::String>("If key argument is given, it must be a Buffer").ToLocalChecked()));
+				}
+				key_data = node::Buffer::Data(info[1]);
+				key_length = node::Buffer::Length(info[1]);
 			}
-			key_data = node::Buffer::Data(info[1]);
-			key_length = node::Buffer::Length(info[1]);
+
+			if (!info[2]->IsNumber()) {
+				return Nan::ThrowError(v8::Exception::TypeError(Nan::New<v8::String>("digestLength must be a number").ToLocalChecked()));
+			}
+			digest_length = info[2]->IntegerValue();
 		}
 
 		if(algo == "bypass") {
 			// Initialize nothing - .copy() will set up all the state
 		} else if(algo == "blake2b") {
+			if (digest_length == -1) {
+				digest_length = BLAKE2B_OUTBYTES;
+			} else if (digest_length < 1 || digest_length > BLAKE2B_OUTBYTES) {
+				return Nan::ThrowError("digestLength must be between 1 and 64");
+			}
+
 			if(!key_data) {
-				if(blake2b_init(reinterpret_cast<blake2b_state*>(&obj->state), BLAKE2B_OUTBYTES) != 0) {
+				if(blake2b_init(reinterpret_cast<blake2b_state*>(&obj->state), digest_length) != 0) {
 					return Nan::ThrowError("blake2b_init failure");
 				}
 			} else {
 				if(key_length > BLAKE2B_KEYBYTES) {
 					return Nan::ThrowError("Key must be 64 bytes or smaller");
 				}
-				if(blake2b_init_key(reinterpret_cast<blake2b_state*>(&obj->state), BLAKE2B_OUTBYTES, key_data, key_length) != 0) {
+				if(blake2b_init_key(reinterpret_cast<blake2b_state*>(&obj->state), digest_length, key_data, key_length) != 0) {
 					return Nan::ThrowError("blake2b_init_key failure");
 				}
 			}
-			obj->outbytes = 512 / 8;
+			obj->outbytes = digest_length;
 			obj->any_blake2_update = BLAKE_FN_CAST(blake2b_update);
 			obj->any_blake2_final = BLAKE_FN_CAST(blake2b_final);
 			obj->initialized_ = true;
 		} else if(algo == "blake2bp") {
+			if (digest_length == -1) {
+				digest_length = BLAKE2B_OUTBYTES;
+			} else if (digest_length < 1 || digest_length > BLAKE2B_OUTBYTES) {
+				return Nan::ThrowError("digestLength must be between 1 and 64");
+			}
+
 			if(!key_data) {
 				if(blake2bp_init(reinterpret_cast<blake2bp_state*>(&obj->state), BLAKE2B_OUTBYTES) != 0) {
 					return Nan::ThrowError("blake2bp_init failure");
@@ -96,41 +116,53 @@ public:
 					return Nan::ThrowError("blake2bp_init_key failure");
 				}
 			}
-			obj->outbytes = 512 / 8;
+			obj->outbytes = digest_length;
 			obj->any_blake2_update = BLAKE_FN_CAST(blake2bp_update);
 			obj->any_blake2_final = BLAKE_FN_CAST(blake2bp_final);
 			obj->initialized_ = true;
 		} else if(algo == "blake2s") {
+			if (digest_length == -1) {
+				digest_length = BLAKE2S_OUTBYTES;
+			} else if (digest_length < 1 || digest_length > BLAKE2S_OUTBYTES) {
+				return Nan::ThrowError("digestLength must be between 1 and 32");
+			}
+
 			if(!key_data) {
-				if(blake2s_init(reinterpret_cast<blake2s_state*>(&obj->state), BLAKE2S_OUTBYTES) != 0) {
+				if(blake2s_init(reinterpret_cast<blake2s_state*>(&obj->state), digest_length) != 0) {
 					return Nan::ThrowError("blake2bs_init failure");
 				}
 			} else {
 				if(key_length > BLAKE2S_KEYBYTES) {
 					return Nan::ThrowError("Key must be 32 bytes or smaller");
 				}
-				if(blake2s_init_key(reinterpret_cast<blake2s_state*>(&obj->state), BLAKE2S_OUTBYTES, key_data, key_length) != 0) {
+				if(blake2s_init_key(reinterpret_cast<blake2s_state*>(&obj->state), digest_length, key_data, key_length) != 0) {
 					return Nan::ThrowError("blake2s_init_key failure");
 				}
 			}
-			obj->outbytes = 256 / 8;
+			obj->outbytes = digest_length;
 			obj->any_blake2_update = BLAKE_FN_CAST(blake2s_update);
 			obj->any_blake2_final = BLAKE_FN_CAST(blake2s_final);
 			obj->initialized_ = true;
 		} else if(algo == "blake2sp") {
+			if (digest_length == -1) {
+				digest_length = BLAKE2S_OUTBYTES;
+			} else if (digest_length < 1 || digest_length > BLAKE2S_OUTBYTES) {
+				return Nan::ThrowError("digestLength must be between 1 and 32");
+			}
+
 			if(!key_data) {
-				if(blake2sp_init(reinterpret_cast<blake2sp_state*>(&obj->state), BLAKE2S_OUTBYTES) != 0) {
+				if(blake2sp_init(reinterpret_cast<blake2sp_state*>(&obj->state), digest_length) != 0) {
 					return Nan::ThrowError("blake2sp_init failure");
 				}
 			} else {
 				if(key_length > BLAKE2S_KEYBYTES) {
 					return Nan::ThrowError("Key must be 32 bytes or smaller");
 				}
-				if(blake2sp_init_key(reinterpret_cast<blake2sp_state*>(&obj->state), BLAKE2S_OUTBYTES, key_data, key_length) != 0) {
+				if(blake2sp_init_key(reinterpret_cast<blake2sp_state*>(&obj->state), digest_length, key_data, key_length) != 0) {
 					return Nan::ThrowError("blake2sp_init_key failure");
 				}
 			}
-			obj->outbytes = 256 / 8;
+			obj->outbytes = digest_length;
 			obj->any_blake2_update = BLAKE_FN_CAST(blake2sp_update);
 			obj->any_blake2_final = BLAKE_FN_CAST(blake2sp_final);
 			obj->initialized_ = true;

--- a/tests/blake2.js
+++ b/tests/blake2.js
@@ -14,6 +14,11 @@ const BLAKE2S_EMPTY_DIGEST_HEX = '69217a3079908094e11121d042354a7c1f55b6482ca1a5
 const BLAKE2S_EMPTY_DIGEST_BASE64 = new Buffer(BLAKE2S_EMPTY_DIGEST_HEX, 'hex').toString('base64');
 const BLAKE2S_EMPTY_DIGEST_BINARY = new Buffer(BLAKE2S_EMPTY_DIGEST_HEX, 'hex').toString('binary');
 
+const BLAKE2B_TEST_DIGEST_16_HEX = '44a8995dd50b6657a037a7839304535b';
+const BLAKE2BP_TEST_DIGEST_16_HEX = 'ec93bfef647e0f82f040b4e81d4d7491';
+const BLAKE2S_TEST_DIGEST_16_HEX = 'e9ddd9926b9dcb382e09be39ba403d2c';
+const BLAKE2SP_TEST_DIGEST_16_HEX = 'ef8ec7f654a5c35898b7b0e4ab13c174';
+
 /**
  * Parse the test vectors from a BLAKE2 test vector file
  */
@@ -132,6 +137,26 @@ describe('blake2', function() {
 				new blake2.KeyedHash('blake2b', new Buffer('x'.repeat(64 + 1), "ascii"));
 			}, /must be 64 bytes or smaller/);
 		});
+		it('throws Error if called with a non-numeric digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2b', { digestLength: 'not a number' });
+			}, /must be a number/);
+		});
+		it('throws Error if called with a too large digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2b', { digestLength: 65 });
+			}, /must be between 1 and 64/);
+		});
+		it('throws Error if called with a too small digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2b', { digestLength: 0 });
+			}, /must be between 1 and 64/);
+		});
+		it('returns the correct hash for a 16 byte digestLength', function() {
+			const hash = new blake2.Hash('blake2b', { digestLength: 16 });
+			hash.update(new Buffer('test'));
+			assert.equal(hash.digest('hex'), BLAKE2B_TEST_DIGEST_16_HEX);
+		});
 	});
 
 	describe('blake2bp', function() {
@@ -139,6 +164,26 @@ describe('blake2', function() {
 			assert.throws(function() {
 				new blake2.KeyedHash('blake2bp', new Buffer('x'.repeat(64 + 1), "ascii"));
 			}, /must be 64 bytes or smaller/);
+		});
+		it('throws Error if called with a non-numeric digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2bp', { digestLength: 'not a number' });
+			}, /must be a number/);
+		});
+		it('throws Error if called with a too large digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2bp', { digestLength: 65 });
+			}, /must be between 1 and 64/);
+		});
+		it('throws Error if called with a too small digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2bp', { digestLength: 0 });
+			}, /must be between 1 and 64/);
+		});
+		it('returns the correct hash for a 16 byte digestLength', function() {
+			const hash = new blake2.Hash('blake2bp', { digestLength: 16 });
+			hash.update(new Buffer('test'));
+			assert.equal(hash.digest('hex'), BLAKE2BP_TEST_DIGEST_16_HEX);
 		});
 	});
 
@@ -148,6 +193,26 @@ describe('blake2', function() {
 				new blake2.KeyedHash('blake2s', new Buffer('x'.repeat(32 + 1), "ascii"));
 			}, /must be 32 bytes or smaller/);
 		});
+		it('throws Error if called with a non-numeric digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2s', { digestLength: 'not a number' });
+			}, /must be a number/);
+		});
+		it('throws Error if called with a too large digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2s', { digestLength: 33});
+			}, /must be between 1 and 32/);
+		});
+		it('throws Error if called with a too small digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2s', { digestLength: 0 });
+			}, /must be between 1 and 32/);
+		});
+		it('returns the correct hash for a 16 byte digestLength', function() {
+			const hash = new blake2.Hash('blake2s', { digestLength: 16 });
+			hash.update(new Buffer('test'));
+			assert.equal(hash.digest('hex'), BLAKE2S_TEST_DIGEST_16_HEX);
+		});
 	});
 
 	describe('blake2sp', function() {
@@ -155,6 +220,26 @@ describe('blake2', function() {
 			assert.throws(function() {
 				new blake2.KeyedHash('blake2sp', new Buffer('x'.repeat(32 + 1), "ascii"));
 			}, /must be 32 bytes or smaller/);
+		});
+		it('throws Error if called with a non-numeric digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2sp', { digestLength: 'not a number' });
+			}, /must be a number/);
+		});
+		it('throws Error if called with a too large digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2sp', { digestLength: 33});
+			}, /must be between 1 and 32/);
+		});
+		it('throws Error if called with a too small digestLength', function() {
+			assert.throws(function() {
+				new blake2.Hash('blake2sp', { digestLength: 0 });
+			}, /must be between 1 and 32/);
+		});
+		it('returns the correct hash for a 16 byte digestLength', function() {
+			const hash = new blake2.Hash('blake2sp', { digestLength: 16 });
+			hash.update(new Buffer('test'));
+			assert.equal(hash.digest('hex'), BLAKE2SP_TEST_DIGEST_16_HEX);
 		});
 	});
 


### PR DESCRIPTION
BLAKE2 supports calculating digests of varying lengths, between 1 and
(maximum number of bytes for the algorithm).

Add support for this, via `digestLength` in the options object.