### PR TITLE
Fix Node 10 build by not using 2-arg v8::Function::NewInstance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - TRAVIS_NODE_VERSION="6"
   - TRAVIS_NODE_VERSION="7"
   - TRAVIS_NODE_VERSION="8"
+  - TRAVIS_NODE_VERSION="10"
 
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -230,8 +230,8 @@ public:
 		const unsigned argc = 1;
 		v8::Local<v8::Value> argv[argc] = { Nan::New<v8::String>("bypass").ToLocalChecked() };
 
-		v8::Local<v8::FunctionTemplate> construct = Nan::New<v8::FunctionTemplate>(hash_constructor);
-		v8::Local<v8::Object> inst = construct->GetFunction()->NewInstance(argc, argv);
+		v8::Local<v8::Function> construct = Nan::New<v8::FunctionTemplate>(hash_constructor)->GetFunction();
+		v8::Local<v8::Object> inst = Nan::NewInstance(construct, argc, argv).ToLocalChecked();
 		// Construction may fail with a JS exception, in which case we just need
 		// to return.
 		if (inst.IsEmpty()) {


### PR DESCRIPTION
The function has been deprecated for a while and Node 10's V8 doesn't have it.

I tested by building and running tests with Node 4.3.1, 8.11.1, 10.4.1.

I've never written V8 binding code before, so I'm not sure if this is the right fix.  I just found another project that had the same issue and this is how they fixed it :-P