### PR TITLE
Upgrade nan dependency to fix building with node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "test-strong-mode": "node --strong-mode ./node_modules/.bin/_mocha tests/*.js"
   },
   "dependencies": {
-    "nan": "^2.0.0"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
-    "eslint": "^1.0.0",
-    "mocha": "^2.2.5"
+    "eslint": "^6.1.0",
+    "mocha": "^6.2.0"
   },
   "author": "Ivan Kozik",
   "license": "ISC",


### PR DESCRIPTION
When installed as transitive dependency on node 10, `node-blake2` build fails:

```
  CXX(target) Release/obj.target/binding/src/binding.o                             
In file included from ../../nan/nan.h:190:0,        
                 from ../src/binding.cpp:4:                                          
../../nan/nan_maybe_43_inl.h: In function 'Nan::Maybe<bool> Nan::ForceSet(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Value>, v8::PropertyAttribute)':
../../nan/nan_maybe_43_inl.h:88:15: error: 'class v8::Object' has no member named 'ForceSet'                           
   return obj->ForceSet(GetCurrentContext(), key, value, attribs);                                                                                       
               ^~~~~~~~     
```

This PR explicitly updates `nan` to a more recent version.

Also upgraded `mocha` and `tslint` tools because of security vulnerabilities in some of their dependencies.

Related issue: https://github.com/ludios/node-blake2/issues/10