### PR TITLE
Upgrade nan dependency to 2.14.0, to support linking against node 10 (PR #2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-strong-mode": "node --strong-mode ./node_modules/.bin/_mocha tests/*.js"
   },
   "dependencies": {
-    "nan": "^2.0.0"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "eslint": "^1.0.0",


### PR DESCRIPTION
When installed as transitive dependency on node 10, node-blake2 build fails:

```
  CXX(target) Release/obj.target/binding/src/binding.o                             
In file included from ../../nan/nan.h:190:0,        
                 from ../src/binding.cpp:4:                                          
../../nan/nan_maybe_43_inl.h: In function 'Nan::Maybe<bool> Nan::ForceSet(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Value>, v8::PropertyAttribute)':
../../nan/nan_maybe_43_inl.h:88:15: error: 'class v8::Object' has no member named 'ForceSet'                           
   return obj->ForceSet(GetCurrentContext(), key, value, attribs);                                                                                       
               ^~~~~~~~     
```

This PR explicitly updates nan to the most recent version.

Related issue: #10